### PR TITLE
chrome-duplicate-tab.applescript: do not emulate key strokes

### DIFF
--- a/AppleScripts/chrome-duplicate-tab.applescript
+++ b/AppleScripts/chrome-duplicate-tab.applescript
@@ -1,8 +1,9 @@
 -- Duplicate Chrome's currently open tab in the background
--- by Jordan Saints, www.jordansaints.com
 
 tell application "Google Chrome"
 	activate
+	tell front window
+		set theURL to URL of active tab
+		make new tab with properties {URL:theURL}
+	end tell
 end tell
-tell application "System Events" to key code 37 using {command down} -- cmd+L focuses on omnibar
-tell application "System Events" to key code 36 using {command down} -- cmd+Return duplicates tab in background


### PR DESCRIPTION
Faking key strokes is error prone. Chrome has proper AppleScript support for this.